### PR TITLE
Thumbnails and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ module.exports = ({ env }) => ({
     providerOptions: {
       apiKey: env('ROKKA_API_KEY'),
       org: env('ROKKA_ORG'),
-      orgUrl: env('ROKKA_ORG_URL'),
+      orgUrl: env('ROKKA_ORG_URL'), 
+      uploadThumbnail: true
     },
   },
 });
@@ -43,6 +44,7 @@ module.exports = ({ env }) => ({
               apiKey: env('ROKKA_API_KEY'),
               org: env('ROKKA_ORG'),
               orgUrl: env('ROKKA_ORG_URL'),
+              uploadThumbnail: true
           },
       }
   },
@@ -69,5 +71,16 @@ Edit `config/middlewares.js` and replace `strapi::security` with
   }
 ```
 
-You can also disable `Enable responsive friendly upload` in your media library settings, otherwise you get the same image
+You should also disable `Enable responsive friendly upload` in your media library settings, otherwise you get the same image
 with different sizes in rokka, which is not needed. Rokka handles the resizing for you.
+
+# Config Options
+
+## uploadThumbnail
+
+Strapi uploads for each image also a "thumbnail" image for using in the media manager and other previews. This will
+generate another small source image on rokka, but prevents having to download the maybe big source image in those previews.
+Rokka could of course also generate that thumbnail out of the original source image without needing two source images, 
+but we couldn't figure out a way to do that.
+
+You can disable that feature with setting it to `false` or removing the attribute from the config file. 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Edit `config/middlewares.js` and replace `strapi::security` with
         useDefaults: true,
         directives: {
           'img-src': ["https:", 'data:', 'blob:', "'self'"],
+          'media-src':["https:", 'data:', 'blob:', "'self'"] // for videos hosted on rokka
         },
       },
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,8 +21,10 @@ module.exports = {
         const metadata = {
           'meta_user': {
             alt: file.alternativeText,
-            caption: file.caption
+            caption: file.caption,
+            uploadedby: 'strapi',
             thumbnail: isThumbnail ? 'yes': 'no',
+            "array:albums": ['strapi'] // if you use https://rokka.io/gallery the pictures uploaded through this will be in there own album
           }
         }
 
@@ -30,6 +32,13 @@ module.exports = {
           .then((result) => {
             file.hash = result.body.items[0].hash
             file.url = options.orgUrl + 'dynamic/' + result.body.items[0].hash + '.' + result.body.items[0].format
+            const item = result.body.items[0]
+            //add some additional metadata for later use
+            file.provider_metadata = {
+              hash: item.hash,
+              format: item.format,
+              mimetype: item.mimetype
+            }
           })
           .catch((err) => {}); // TODO: handle error
       },

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,8 +8,13 @@ module.exports = {
 
     return {
       upload(file) {
-        // TODO: investigate how to disable thumbnail upload
-        if (file.name.startsWith('thumbnail_')) {
+        const isThumbnail = file.name.startsWith('thumbnail_')
+        // only upload thumbnails, if set in the config.
+        // but it helps to generate previews in the media manager (or not make them downloading the
+        // super big original).
+        // Rokka could handle that, of course, but didn't find an easy way to do that without uploading
+        // the thumbnail as its own image.
+        if (isThumbnail && !options.uploadThumbnail === true) {
           return
         }
 
@@ -17,6 +22,7 @@ module.exports = {
           'meta_user': {
             alt: file.alternativeText,
             caption: file.caption
+            thumbnail: isThumbnail ? 'yes': 'no',
           }
         }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,15 @@ module.exports = {
             uploadedby: 'strapi',
             thumbnail: isThumbnail ? 'yes': 'no',
             "array:albums": ['strapi'] // if you use https://rokka.io/gallery the pictures uploaded through this will be in there own album
+          },
+          // To prevent that we delete an image on rokka, when it's uploaded in two different medias, we set a so called
+          // dynamic metadata version (https://rokka.io/documentation/references/dynamic-metadata.html#version )
+          // So each uploaded image, even if it's the same binary, gets an unique hash and if we delete one
+          // only that entry is deleted and not the others with the same binaries. And won't use more storage on
+          // rokka's side.
+          // file.hash seems to be different for each upload, even if the same binary is uploaded again
+          'meta_dynamic': {
+            version: {text: file.hash}
           }
         }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,12 +45,17 @@ module.exports = {
               mimetype: item.mimetype
             }
           })
-          .catch((err) => {}); // TODO: handle error
+          .catch((err) => {
+            throw new Error (`Error creating on rokka: ${JSON.stringify(err)}`);}
+          );
       },
       delete(file) {
         return rokka.sourceimages.delete(options.org, file.hash)
           .then((result) => {})
-          .catch((err) => {}); // TODO: handle error
+          .catch((err) => {
+            // It's fine to just log it and not throw an error
+            console.log(`Error deleting on rokka: ${JSON.stringify(err)}`)
+          });
       },
     };
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,8 @@ module.exports = {
             // done, so we can upload display them in the media manager if some exotic format
             const format = (item.format !== 'jpg' && item.format !== 'png') ? 'jpg' : item.format
             file.url = options.orgUrl + 'dynamic/o-af-1/' + item.short_hash + '.' + format
+            // preview URL only seems to make sense for videos, but it doesn't hurt either
+            file.previewUrl = options.orgUrl + 'dynamic/resize-width-200-height-200-mode-box/o-af-1/' + item.short_hash + '.jpg'
             //add some additional metadata for later use
             file.provider_metadata = {
               hash: item.hash,

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,9 +30,12 @@ module.exports = {
 
         return rokka.sourceimages.create(options.org, file.name, file.buffer, metadata)
           .then((result) => {
-            file.hash = result.body.items[0].hash
-            file.url = options.orgUrl + 'dynamic/' + result.body.items[0].hash + '.' + result.body.items[0].format
             const item = result.body.items[0]
+            file.hash = item.short_hash //store the short hash, it just gives shorter urls
+            // only use jpg or png as format endings in the url (maybe check what to do with pdf and videos)
+            // done, so we can upload display them in the media manager if some exotic format
+            const format = (item.format !== 'jpg' && item.format !== 'png') ? 'jpg' : item.format
+            file.url = options.orgUrl + 'dynamic/o-af-1/' + item.short_hash + '.' + format
             //add some additional metadata for later use
             file.provider_metadata = {
               hash: item.hash,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "rokka": "^3.0.0-rc.1"
+    "rokka": "^3.0"
   },
   "strapi": {
     "isProvider": true


### PR DESCRIPTION
Lots of additions, should be totally backwards compatible. I made commits for each new "feature", for a better overview. If you'd like them in seperate MRs, I can do that. Or discuss things you don't agree ;)

- remove the rc-1 in package.json for rokka.js
- Allow uploads of thumbnails for smaller images in media manager previews
- Add some rokka metadata, could be useful later
- Use short_hash instead of the long hash, always use jpg or png as format extension to display "exotic" formats
- Add a previewUrl (only helpful for videos)
- Throw an error, when uploading doesn't work
- Add a dynamic metadata version to prevent deletion of images uploaded twice as different entities
- Add media-src in the README for the CSP middleware to display videos
